### PR TITLE
add support for arm 32 when golang < 1.15

### DIFF
--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -372,6 +372,9 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	targetOS := os
 	if os == "ios" {
 		targetOS = "darwin"
+		if supports32bitsArchs() {
+			return targetOS, []string{"arm", "arm64", "amd64"}, nil
+		}
 		return targetOS, []string{"arm64", "amd64"}, nil
 	}
 	if os == "android" {
@@ -384,7 +387,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	}
 	if os == "macos-ui" {
 		targetOS = "darwin"
-		return targetOS,  []string{"uikitMac64"}, nil
+		return targetOS, []string{"uikitMac64"}, nil
 	}
 
 	seen := map[string]bool{}
@@ -399,7 +402,6 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 		seen[arch] = true
 		archs = append(archs, arch)
 	}
-
 
 	if all {
 		return targetOS, allArchs(os), nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module golang.org/x/mobile
 go 1.11
 
 require (
+	github.com/hashicorp/go-version v1.2.1
 	golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56
 	golang.org/x/image v0.0.0-20190802002840-cff245a6509b
 	golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Merge the ios32 branch with master, and add conditionals, to support armmv7 only if golang < 1.15.