### PR TITLE
Modify the build tool to support macos with arm64 (new apple silicon macs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go support for Mobile devices
 
+[![Go Reference](https://pkg.go.dev/badge/golang.org/x/mobile.svg)](https://pkg.go.dev/golang.org/x/mobile)
+
 The Go mobile repository holds packages and build tools for using Go on mobile platforms.
 
 Package documentation as a starting point:

--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -291,7 +291,7 @@ func writeGoMod(targetOS string, targetArch string) error {
 	if targetArch == "macos64" || targetArch == "uikitMac64" {
 		targetArch = "amd64"
 	}
-	if targetArch == "simArm64" {
+	if targetArch == "sim-arm64" {
 		targetArch = "arm64"
 	}
 	m, err := areGoModulesUsed()

--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -291,6 +291,9 @@ func writeGoMod(targetOS string, targetArch string) error {
 	if targetArch == "macos64" || targetArch == "uikitMac64" {
 		targetArch = "amd64"
 	}
+	if targetArch == "simArm64" {
+		targetArch = "arm64"
+	}
 	m, err := areGoModulesUsed()
 	if err != nil {
 		return err

--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -288,10 +288,9 @@ func getModuleVersions(targetOS string, targetArch string, src string) (*modfile
 
 // writeGoMod writes go.mod file at $WORK/src when Go modules are used.
 func writeGoMod(targetOS string, targetArch string) error {
-	if targetArch == "macos64" || targetArch == "uikitMac64" || targetArch == "sim-amd64" {
+	if targetArch == "macos-amd64" || targetArch == "uikitMac-amd64" || targetArch == "sim-amd64" {
 		targetArch = "amd64"
-	}
-	if targetArch == "sim-arm64" {
+	} else if targetArch == "macos-arm64" || targetArch == "uikitMac-arm64" || targetArch == "sim-arm64" {
 		targetArch = "arm64"
 	}
 	m, err := areGoModulesUsed()

--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -288,7 +288,7 @@ func getModuleVersions(targetOS string, targetArch string, src string) (*modfile
 
 // writeGoMod writes go.mod file at $WORK/src when Go modules are used.
 func writeGoMod(targetOS string, targetArch string) error {
-	if targetArch == "macos64" || targetArch == "uikitMac64" {
+	if targetArch == "macos64" || targetArch == "uikitMac64" || targetArch == "sim-amd64" {
 		targetArch = "amd64"
 	}
 	if targetArch == "sim-arm64" {

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -373,9 +373,13 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	if os == "ios" {
 		targetOS = "darwin"
 		if supports32bitsArchs() {
-			return targetOS, []string{"arm", "arm64", "amd64", "simArm64"}, nil
+			return targetOS, []string{"arm", "arm64", "amd64"}, nil
 		}
-		return targetOS, []string{"arm64", "amd64", "simArm64"}, nil
+		return targetOS, []string{"arm64", "amd64"}, nil
+	}
+	if os == "sim-arm64" {
+		targetOS = "darwin"
+		return targetOS, []string{"sim-arm64"}, nil
 	}
 	if os == "android" {
 		return targetOS, []string{"arm", "arm64", "386", "amd64"}, nil

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -387,11 +387,11 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	if os == "macos" {
 		targetOS = "darwin"
 		// allArchs = []string{"macos64"}
-		return targetOS, []string{"macos64"}, nil
+		return targetOS, []string{"macos-arm64", "macos-amd64"}, nil
 	}
 	if os == "macos-ui" {
 		targetOS = "darwin"
-		return targetOS, []string{"uikitMac64"}, nil
+		return targetOS, []string{"uikitMac-arm64", "uikitMac-amd64"}, nil
 	}
 
 	seen := map[string]bool{}

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -373,13 +373,13 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	if os == "ios" {
 		targetOS = "darwin"
 		if supports32bitsArchs() {
-			return targetOS, []string{"arm", "arm64", "amd64"}, nil
+			return targetOS, []string{"arm", "arm64"}, nil
 		}
-		return targetOS, []string{"arm64", "amd64"}, nil
+		return targetOS, []string{"arm64"}, nil
 	}
-	if os == "sim-arm64" {
+	if os == "ios-simulator" {
 		targetOS = "darwin"
-		return targetOS, []string{"sim-arm64"}, nil
+		return targetOS, []string{"arm64, amd64"}, nil
 	}
 	if os == "android" {
 		return targetOS, []string{"arm", "arm64", "386", "amd64"}, nil

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -379,7 +379,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	}
 	if os == "ios-simulator" {
 		targetOS = "darwin"
-		return targetOS, []string{"arm64, amd64"}, nil
+		return targetOS, []string{"sim-arm64", "sim-amd64"}, nil
 	}
 	if os == "android" {
 		return targetOS, []string{"arm", "arm64", "386", "amd64"}, nil

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -340,7 +340,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	archNames := []string{}
 	for i, p := range strings.Split(buildTarget, ",") {
 		osarch := strings.SplitN(p, "/", 2) // len(osarch) > 0
-		if osarch[0] != "android" && osarch[0] != "ios" && osarch[0] != "macos" && osarch[0] != "macos-ui" {
+		if osarch[0] != "android" && osarch[0] != "ios" && osarch[0] != "macos" && osarch[0] != "macos-ui" && osarch[0] != "sim-arm64" {
 			return "", nil, fmt.Errorf(`unsupported os`)
 		}
 

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -373,9 +373,9 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	if os == "ios" {
 		targetOS = "darwin"
 		if supports32bitsArchs() {
-			return targetOS, []string{"arm", "arm64", "amd64"}, nil
+			return targetOS, []string{"arm", "arm64", "amd64", "simArm64"}, nil
 		}
-		return targetOS, []string{"arm64", "amd64"}, nil
+		return targetOS, []string{"arm64", "amd64", "simArm64"}, nil
 	}
 	if os == "android" {
 		return targetOS, []string{"arm", "arm64", "386", "amd64"}, nil

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -340,7 +340,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	archNames := []string{}
 	for i, p := range strings.Split(buildTarget, ",") {
 		osarch := strings.SplitN(p, "/", 2) // len(osarch) > 0
-		if osarch[0] != "android" && osarch[0] != "ios" && osarch[0] != "macos" && osarch[0] != "macos-ui" && osarch[0] != "sim-arm64" {
+		if osarch[0] != "android" && osarch[0] != "ios" && osarch[0] != "macos" && osarch[0] != "macos-ui" && osarch[0] != "ios-simulator" {
 			return "", nil, fmt.Errorf(`unsupported os`)
 		}
 

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -315,6 +315,8 @@ func archClang(goarch string) string {
 		return "x86_64"
 	case "sim-arm64":
 		return "arm64"
+	case "sim-amd64":
+		return "x86_64"
 	case "uikitMac64":
 		return "x86_64"
 	default:

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -326,10 +326,10 @@ func archClang(goarch string) string {
 		return "x86_64"
 	case "macos-arm64":
 		return "arm64"
-	case "sim-arm64":
-		return "arm64"
 	case "sim-amd64":
 		return "x86_64"
+	case "sim-arm64":
+		return "arm64"
 	case "uikitMac-amd64":
 		return "x86_64"
 	case "uikitMac-arm64":

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -67,9 +67,9 @@ func allArchs(targetOS string) []string {
 	case "android":
 		return []string{"arm", "arm64", "386", "amd64"}
 	case "macos":
-		return []string{"macos64"}
+		return []string{"macos-arm64", "macos-amd64"}
 	case "macos-ui":
-		return []string{"uikitMac64"}
+		return []string{"uikitMac-arm64", "uikitMac-amd64"}
 	default:
 		panic(fmt.Sprintf("unexpected target OS: %s", targetOS))
 	}
@@ -211,17 +211,28 @@ func envInit() (err error) {
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion
 			archNew = "arm64"
-		case "macos64":
+		case "macos-amd64":
 			clang, cflags, err = envClang("macosx")
 			cflags += " -mmacosx-version-min=10.10"
 			archNew = "amd64"
-		case "uikitMac64":
+		case "macos-arm64":
+			clang, cflags, err = envClang("macosx")
+			cflags += " -mmacosx-version-min=10.10"
+			archNew = "arm64"
+		case "uikitMac-amd64":
 			clang, cflags, err = envClang("macosx15")
 			cflags += " --target=x86_64-apple-ios13.0-macabi"
 			// cflags += " -miphoneos-version-min=13.0"
 			// cflags += " -mmacosx-version-min=10.15"
 
 			archNew = "amd64"
+		case "uikitMac-arm64":
+			clang, cflags, err = envClang("macosx15")
+			cflags += " --target=x86_64-apple-ios13.0-macabi"
+			// cflags += " -miphoneos-version-min=13.0"
+			// cflags += " -mmacosx-version-min=10.15"
+
+			archNew = "arm64"
 		default:
 			panic(fmt.Errorf("unknown GOARCH: %q", arch))
 		}
@@ -311,14 +322,18 @@ func archClang(goarch string) string {
 		return "i386"
 	case "amd64":
 		return "x86_64"
-	case "macos64":
+	case "macos-amd64":
 		return "x86_64"
+	case "macos-arm64":
+		return "arm64"
 	case "sim-arm64":
 		return "arm64"
 	case "sim-amd64":
 		return "x86_64"
-	case "uikitMac64":
+	case "uikitMac-amd64":
 		return "x86_64"
+	case "uikitMac-arm64":
+		return "arm64"
 	default:
 		panic(fmt.Sprintf("unknown GOARCH: %q", goarch))
 	}

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -59,11 +59,11 @@ func allArchs(targetOS string) []string {
 	switch targetOS {
 	case "ios":
 		if supports32bitsArchs() {
-			return []string{"arm", "arm64", "amd64"}
+			return []string{"arm", "arm64"}
 		}
-		return []string{"arm64", "amd64"}
-	case "sim-arm64":
-		return []string{"sim-arm64"}
+		return []string{"arm64"}
+	case "ios-simulator":
+		return []string{"sim-amd64", "sim-arm64"}
 	case "android":
 		return []string{"arm", "arm64", "386", "amd64"}
 	case "macos":
@@ -183,6 +183,7 @@ func envInit() (err error) {
 	darwinArchs := allArchs("ios")
 	darwinArchs = append(darwinArchs, allArchs("macos")...)
 	darwinArchs = append(darwinArchs, allArchs("macos-ui")...)
+	darwinArchs = append(darwinArchs, allArchs("ios-simulator")...)
 	for _, arch := range darwinArchs {
 		var env []string
 		var err error
@@ -202,9 +203,10 @@ func envInit() (err error) {
 		case "arm64":
 			clang, cflags, err = envClang("iphoneos")
 			cflags += " -miphoneos-version-min=" + buildIOSVersion
-		case "amd64":
+		case "sim-amd64":
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion
+			archNew = "amd64"
 		case "sim-arm64":
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion
@@ -294,14 +296,6 @@ func envClang(sdkName string) (clang, cflags string, err error) {
 		return "", "", fmt.Errorf("xcrun --show-sdk-path: %v\n%s", err, out)
 	}
 	sdk := strings.TrimSpace(string(out))
-	fmt.Println(clang)
-	fmt.Println(sdk)
-	// if inSDKname == "macosx15" {
-	// 	clang = "/Users/Yanfeng/Downloads/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
-	// 	// sdk = "/Users/Yanfeng/Downloads/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.0.sdk"
-	// 	sdk = "/Users/Yanfeng/Downloads/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk"
-	// 	// sdk = "/Users/Yanfeng/Downloads/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.0.sdk"
-	// }
 	fmt.Println(clang)
 	fmt.Println(sdk)
 	return clang, "-isysroot " + sdk, nil

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -59,9 +59,11 @@ func allArchs(targetOS string) []string {
 	switch targetOS {
 	case "ios":
 		if supports32bitsArchs() {
-			return []string{"arm", "arm64", "amd64", "simArm64"}
+			return []string{"arm", "arm64", "amd64"}
 		}
-		return []string{"arm64", "amd64", "simArm64"}
+		return []string{"arm64", "amd64"}
+	case "sim-arm64":
+		return []string{"sim-arm64"}
 	case "android":
 		return []string{"arm", "arm64", "386", "amd64"}
 	case "macos":
@@ -203,7 +205,7 @@ func envInit() (err error) {
 		case "amd64":
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion
-		case "simArm64":
+		case "sim-arm64":
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion
 			archNew = "arm64"
@@ -317,6 +319,8 @@ func archClang(goarch string) string {
 		return "x86_64"
 	case "macos64":
 		return "x86_64"
+	case "sim-arm64":
+		return "arm64"
 	case "uikitMac64":
 		return "x86_64"
 	default:

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -59,9 +59,9 @@ func allArchs(targetOS string) []string {
 	switch targetOS {
 	case "ios":
 		if supports32bitsArchs() {
-			return []string{"arm", "arm64", "amd64"}
+			return []string{"arm", "arm64", "amd64", "simArm64"}
 		}
-		return []string{"arm64", "amd64"}
+		return []string{"arm64", "amd64", "simArm64"}
 	case "android":
 		return []string{"arm", "arm64", "386", "amd64"}
 	case "macos":
@@ -203,6 +203,10 @@ func envInit() (err error) {
 		case "amd64":
 			clang, cflags, err = envClang("iphonesimulator")
 			cflags += " -mios-simulator-version-min=" + buildIOSVersion
+		case "simArm64":
+			clang, cflags, err = envClang("iphonesimulator")
+			cflags += " -mios-simulator-version-min=" + buildIOSVersion
+			archNew = "arm64"
 		case "macos64":
 			clang, cflags, err = envClang("macosx")
 			cflags += " -mmacosx-version-min=10.10"

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -228,7 +228,7 @@ func envInit() (err error) {
 			archNew = "amd64"
 		case "uikitMac-arm64":
 			clang, cflags, err = envClang("macosx15")
-			cflags += " --target=x86_64-apple-ios13.0-macabi"
+			cflags += " --target=arm64-apple-ios13.0-macabi"
 			// cflags += " -miphoneos-version-min=13.0"
 			// cflags += " -mmacosx-version-min=10.15"
 

--- a/gl/work.c
+++ b/gl/work.c
@@ -356,7 +356,7 @@ uintptr_t processFn(struct fnargs* args, char* parg) {
 		glScissor((GLint)args->a0, (GLint)args->a1, (GLint)args->a2, (GLint)args->a3);
 		break;
 	case glfnShaderSource:
-#if defined(os_ios) || defined(os_osx)
+#if defined(os_ios) || defined(os_macos)
 		glShaderSource((GLuint)args->a0, (GLsizei)args->a1, (const GLchar *const *)args->a2, NULL);
 #else
 		glShaderSource((GLuint)args->a0, (GLsizei)args->a1, (const GLchar **)args->a2, NULL);

--- a/gl/work.go
+++ b/gl/work.go
@@ -7,23 +7,19 @@
 package gl
 
 /*
-#cgo ios                LDFLAGS: -framework OpenGLES
-#cgo darwin,amd64,!ios  LDFLAGS: -framework OpenGL
-#cgo darwin,arm         LDFLAGS: -framework OpenGLES
-#cgo darwin,arm64       LDFLAGS: -framework OpenGLES
-#cgo linux              LDFLAGS: -lGLESv2
-#cgo openbsd            LDFLAGS: -L/usr/X11R6/lib/ -lGLESv2
+#cgo ios          LDFLAGS: -framework OpenGLES
+#cgo darwin,!ios  LDFLAGS: -framework OpenGL
+#cgo linux        LDFLAGS: -lGLESv2
+#cgo openbsd      LDFLAGS: -L/usr/X11R6/lib/ -lGLESv2
 
-#cgo android            CFLAGS: -Dos_android
-#cgo ios                CFLAGS: -Dos_ios
-#cgo darwin,amd64,!ios  CFLAGS: -Dos_osx
-#cgo darwin,arm         CFLAGS: -Dos_ios
-#cgo darwin,arm64       CFLAGS: -Dos_ios
-#cgo darwin             CFLAGS: -DGL_SILENCE_DEPRECATION
-#cgo linux              CFLAGS: -Dos_linux
-#cgo openbsd            CFLAGS: -Dos_openbsd
+#cgo android      CFLAGS: -Dos_android
+#cgo ios          CFLAGS: -Dos_ios
+#cgo darwin,!ios  CFLAGS: -Dos_macos
+#cgo darwin       CFLAGS: -DGL_SILENCE_DEPRECATION
+#cgo linux        CFLAGS: -Dos_linux
+#cgo openbsd      CFLAGS: -Dos_openbsd
 
-#cgo openbsd            CFLAGS: -I/usr/X11R6/include/
+#cgo openbsd      CFLAGS: -I/usr/X11R6/include/
 
 #include <stdint.h>
 #include "work.h"

--- a/gl/work.h
+++ b/gl/work.h
@@ -18,7 +18,7 @@
 #include <OpenGLES/ES2/glext.h>
 #endif
 
-#ifdef os_osx
+#ifdef os_macos
 #include <OpenGL/gl3.h>
 #define GL_ES_VERSION_3_0 1
 #endif


### PR DESCRIPTION
We modified the go-mobile to support macos builds (and simulator builds) with arm64.

This allows to build for the new silicon macs that use the arm64 architecture.

The target `macos`, `ios-simulator` and `macos-ui` now generate builds for both amd64 and arm64