### PR TITLE
cmd/gomobile: add support for Apple TV and XROS

### DIFF
--- a/cmd/gomobile/bind_iosapp.go
+++ b/cmd/gomobile/bind_iosapp.go
@@ -321,7 +321,7 @@ func frameworkLayoutForTarget(t targetInfo, title string) (*frameworkLayout, err
 				filepath.Join("Versions/Current", title): title,
 			},
 		}, nil
-	case "ios", "iossimulator":
+	case "ios", "iossimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator":
 		return &frameworkLayout{
 			headerPath:    "Headers",
 			binaryPath:    ".",

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -246,6 +246,8 @@ var (
 	buildWork         bool        // -work
 	buildBundleID     string      // -bundleid
 	buildIOSVersion   string      // -iosversion
+	buildTVOSVersion  string      // -tvosversion
+	buildXROSVersion  string      // -xrosversion
 	buildMacOSVersion string      // -macosversion
 	buildAndroidAPI   int         // -androidapi
 	buildTags         stringsFlag // -tags
@@ -257,8 +259,10 @@ func addBuildFlags(cmd *command) {
 	cmd.flag.StringVar(&buildLdflags, "ldflags", "", "")
 	cmd.flag.StringVar(&buildTarget, "target", "android", "")
 	cmd.flag.StringVar(&buildBundleID, "bundleid", "", "")
-	cmd.flag.StringVar(&buildIOSVersion, "iosversion", "", "")
-	cmd.flag.StringVar(&buildMacOSVersion, "macosversion", "", "")
+	cmd.flag.StringVar(&buildIOSVersion, "iosversion", "13.0", "")
+	cmd.flag.StringVar(&buildTVOSVersion, "tvosversion", "13.0", "")
+	cmd.flag.StringVar(&buildXROSVersion, "xrosversion", "1.0", "")
+	cmd.flag.StringVar(&buildMacOSVersion, "macosversion", "11.0", "")
 	cmd.flag.IntVar(&buildAndroidAPI, "androidapi", minAndroidAPI, "")
 
 	cmd.flag.BoolVar(&buildA, "a", false, "")


### PR DESCRIPTION
Define a minimum deployment target for Apple TV, but not yet for xrOS, as there is currently just one version and the minimum version flags are not yet available for the platform.