### PR TITLE
fix: remove xros from platform list

### DIFF
--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -32,7 +32,7 @@ func isApplePlatform(platform string) bool {
 	return contains(applePlatforms, platform)
 }
 
-var applePlatforms = []string{"ios", "iossimulator", "macos", "maccatalyst", "appletvos", "appletvsimulator", "xros", "xrsimulator"}
+var applePlatforms = []string{"ios", "iossimulator", "macos", "maccatalyst", "appletvos", "appletvsimulator"}
 
 func platformArchs(platform string) []string {
 	switch platform {


### PR DESCRIPTION
This hotfix just removes it from the hard-coded list, because it was causing issues when the xros runtime wasn't installed on the build machines.